### PR TITLE
Add invite-based P2P authentication via passworded QR codes

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -71,6 +71,7 @@ struct AppState {
     p2p_peer_id: String,
     p2p_addrs: Arc<Mutex<Vec<String>>>,
     p2p_dial_tx: mpsc::Sender<String>,
+    invites: Arc<Mutex<HashMap<String, i64>>>, // password -> expiry unix timestamp
     // auth
     sessions: Arc<Mutex<HashMap<String, String>>>, // session_id -> username
 }
@@ -525,6 +526,7 @@ async fn main() -> Result<()> {
         p2p_peer_id,
         p2p_addrs,
         p2p_dial_tx,
+        invites: Arc::new(Mutex::new(std::collections::HashMap::new())),
         // auth
         sessions: Arc::new(Mutex::new(std::collections::HashMap::new())),
     };
@@ -548,6 +550,14 @@ async fn main() -> Result<()> {
         .route("/chunks/:id", get(get_chunk))
         .route("/p2p/info", get(get_p2p_info))
         .route("/p2p/peers", get(get_p2p_peers))
+        .route(
+            "/p2p/invite",
+            post(
+                |state: State<AppState>, _auth: RequireAuth, Json(req): Json<InviteReq>| async move {
+                    post_p2p_invite(state, Json(req)).await
+                },
+            ),
+        )
         .route(
             "/p2p/dial",
             post(
@@ -667,19 +677,57 @@ async fn gallery_html() -> Result<Html<String>, (StatusCode, String)> {
 #[derive(Deserialize)]
 struct DialReq {
     addr: String,
+    password: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct InviteReq {
+    password: String,
+    expires: i64,
 }
 
 async fn post_p2p_dial(
     State(state): State<AppState>,
     Json(req): Json<DialReq>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+    let exp = {
+        let invites = state.invites.lock().unwrap();
+        invites.get(&req.password).copied()
+    };
+    match exp {
+        Some(exp) if now <= exp => {
+            state
+                .p2p_dial_tx
+                .send(req.addr.clone())
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            Ok(Json(
+                serde_json::json!({ "status": "dialing", "addr": req.addr }),
+            ))
+        }
+        _ => Err((StatusCode::UNAUTHORIZED, "invalid or expired invite".into())),
+    }
+}
+
+async fn post_p2p_invite(
+    State(state): State<AppState>,
+    Json(req): Json<InviteReq>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let addr = state
+        .p2p_addrs
+        .lock()
+        .unwrap()
+        .first()
+        .cloned()
+        .ok_or_else(|| (StatusCode::INTERNAL_SERVER_ERROR, "no p2p address".into()))?;
     state
-        .p2p_dial_tx
-        .send(req.addr.clone())
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .invites
+        .lock()
+        .unwrap()
+        .insert(req.password.clone(), req.expires);
     Ok(Json(
-        serde_json::json!({ "status": "dialing", "addr": req.addr }),
+        serde_json::json!({ "addr": addr, "password": req.password, "expires": req.expires }),
     ))
 }
 

--- a/rust/static/index.html
+++ b/rust/static/index.html
@@ -65,10 +65,21 @@
     <h2>Connect to peer</h2>
     <div class="row">
       <input id="addr" type="text" placeholder="/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW…" />
+      <input id="pwd" type="text" placeholder="Password" style="max-width:120px" />
       <button id="dialBtn" onclick="dial()">Dial</button>
       <button id="scanBtn" onclick="openQRScanner()">Scan QR</button>
     </div>
     <div id="status" class="muted" style="margin-top:10px"></div>
+  </section>
+
+  <section class="card">
+    <h2>Create invite QR</h2>
+    <div class="row">
+      <input id="invitePwd" type="text" placeholder="Password" />
+      <input id="inviteExp" type="number" placeholder="Minutes" style="max-width:80px" />
+      <button onclick="createInvite()">Generate</button>
+    </div>
+    <canvas id="inviteQr" style="margin-top:10px"></canvas>
   </section>
 </main>
 <!-- QR Scanner Modal -->
@@ -86,6 +97,8 @@
 
 <!-- jsQR library for decoding QR codes -->
 <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js"></script>
+<!-- QRCode library for generating QR codes -->
+<script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
 
 <script>
 async function loadInfo(){
@@ -117,10 +130,11 @@ async function dial(){
   const btn = document.getElementById('dialBtn');
   const status = document.getElementById('status');
   const addr = document.getElementById('addr').value.trim();
+  const pwd = document.getElementById('pwd').value.trim();
   if(!addr){ status.textContent = 'Enter a multiaddr'; return; }
   btn.disabled = true; status.textContent = 'Dialing…';
   try{
-    const r = await fetch('/p2p/dial', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ addr })});
+    const r = await fetch('/p2p/dial', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ addr, password: pwd })});
     const j = await r.json();
     status.textContent = 'Dialed: ' + j.addr;
   }catch(e){ status.textContent = 'Error: ' + e; }
@@ -178,10 +192,19 @@ function scanLoop(){
   qrRaf = requestAnimationFrame(scanLoop);
 }
 function handleQRResult(text){
-  const addrInput = document.getElementById('addr');
-  addrInput.value = text;
+  try{
+    const obj = JSON.parse(text);
+    if(obj.expires && Date.now() > obj.expires * 1000){
+      alert('Invite expired');
+      closeQRScanner();
+      return;
+    }
+    document.getElementById('addr').value = obj.addr || '';
+    document.getElementById('pwd').value = obj.password || '';
+  }catch{
+    document.getElementById('addr').value = text;
+  }
   closeQRScanner();
-  // auto-dial after successful scan
   if(typeof dial === 'function'){
     dial();
   }
@@ -196,6 +219,17 @@ function closeQRScanner(){
 }
 window.addEventListener('load', ()=>{ loadInfo(); loadPeers(); });
 window.addEventListener('keydown', (e) => { if(e.key === 'Escape') closeQRScanner(); });
+
+async function createInvite(){
+  const pwd = document.getElementById('invitePwd').value.trim();
+  const mins = parseInt(document.getElementById('inviteExp').value, 10);
+  if(!pwd || isNaN(mins)) return;
+  const expires = Math.floor(Date.now()/1000) + mins * 60;
+  const r = await fetch('/p2p/invite', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ password: pwd, expires })});
+  const j = await r.json();
+  const canvas = document.getElementById('inviteQr');
+  QRCode.toCanvas(canvas, JSON.stringify(j), { width: 200 });
+}
 </script>
 </body>
 </html>

--- a/rust/static/peers.html
+++ b/rust/static/peers.html
@@ -60,6 +60,7 @@
     <h2>Connect to peer</h2>
     <div class="row">
       <input id="addr" type="text" placeholder="/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW…" />
+      <input id="pwd" type="text" placeholder="Password" style="max-width:120px" />
       <button id="dialBtn" onclick="dial()">Dial</button>
       <button id="scanBtn" onclick="openQRScanner()">Scan QR</button>
     </div>
@@ -100,10 +101,11 @@ async function dial(){
   const btn = document.getElementById('dialBtn');
   const status = document.getElementById('status');
   const addr = document.getElementById('addr').value.trim();
+  const pwd = document.getElementById('pwd').value.trim();
   if(!addr){ status.textContent = 'Enter a multiaddr'; return; }
   btn.disabled = true; status.textContent = 'Dialing…';
   try{
-    const r = await fetch('/p2p/dial', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ addr })});
+    const r = await fetch('/p2p/dial', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ addr, password: pwd })});
     const j = await r.json();
     status.textContent = 'Dialed: ' + j.addr;
   }catch(e){ status.textContent = 'Error: ' + e; }
@@ -146,8 +148,18 @@ function scanLoop(){
   qrRaf = requestAnimationFrame(scanLoop);
 }
 function handleQRResult(text){
-  const addrInput = document.getElementById('addr');
-  addrInput.value = text;
+  try{
+    const obj = JSON.parse(text);
+    if(obj.expires && Date.now() > obj.expires * 1000){
+      alert('Invite expired');
+      closeQRScanner();
+      return;
+    }
+    document.getElementById('addr').value = obj.addr || '';
+    document.getElementById('pwd').value = obj.password || '';
+  }catch{
+    document.getElementById('addr').value = text;
+  }
   closeQRScanner();
   dial();
 }


### PR DESCRIPTION
## Summary
- require password validation for p2p dial requests using invite list
- add endpoint and UI for generating invite QR codes with expiration
- include password fields in web UI and QR scanning for connections

## Testing
- `cargo test`
- `cargo clippy`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_6899694661c88326b432f30afe3fbad7